### PR TITLE
Use Vite DEV flag for debug layer

### DIFF
--- a/src/components/VectorTileMap.tsx
+++ b/src/components/VectorTileMap.tsx
@@ -216,8 +216,8 @@ const VectorTileMap: React.FC<VectorTileMapProps> = ({
         console.info('layers:', map.current.getStyle().layers?.map(l => l.id));
       } catch {}
       
-        if (process.env.NODE_ENV !== 'production') {
-          // 临时调试图层（固定红色）确认渲染路径
+        if (import.meta.env.DEV) {
+          // 临时调试图层（固定红色）确认渲染路径，仅在开发模式下启用
           map.current.addLayer({
             id: 'debug-dots',
             type: 'circle',
@@ -229,6 +229,8 @@ const VectorTileMap: React.FC<VectorTileMapProps> = ({
               'circle-opacity': 1
             }
           });
+        } else if (map.current.getLayer('debug-dots')) {
+          map.current.removeLayer('debug-dots');
         }
     } else {
       // 更新数据


### PR DESCRIPTION
## Summary
- use `import.meta.env.DEV` instead of `process.env.NODE_ENV` to gate debug map layer
- ensure `debug-dots` layer only appears in development

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689cd9dea7b08321a3f4307fe694fd75